### PR TITLE
Fix container name

### DIFF
--- a/Exome-Seq/tutorials/Exome-Seq.md
+++ b/Exome-Seq/tutorials/Exome-Seq.md
@@ -89,7 +89,7 @@ particularly on the theory behind.
 For this tutorials, you can use the [dedicated Docker image](docker/README.md):
 
 ```
-docker run -d -p 8080:80 bgruening/galaxy-exome-seq-training
+docker run -d -p 8080:80 bgruening/galaxy-training-exome-seq
 ```
 
 It will launch a flavored Galaxy instance available on [http://localhost:8080 ](http://localhost:8080).


### PR DESCRIPTION
I can't pull

```
bgruening/galaxy-exome-seq-training
```

but there is

```
bgruening/galaxy-training-exome-seq
```